### PR TITLE
Configrable object key filter patch

### DIFF
--- a/lua/json/decode/object.lua
+++ b/lua/json/decode/object.lua
@@ -68,10 +68,11 @@ local function buildCapture(options, global_options)
 	if DecimalLpegVersion < 0.9 then
 		objectItems = buildItemSequence(objectItem / applyObjectKey, ignored)
 		objectItems = lpeg.Ca(lpeg.Cc(false) / initObject * objectItems)
+		-- TODO: support options.setObjectKey?
 	-- END LPEG < 0.9 SUPPORT
 	else
 		objectItems = buildItemSequence(lpeg.Cg(objectItem), ignored)
-		objectItems = lpeg.Cf(lpeg.Ct(0) * objectItems, rawset)
+		objectItems = lpeg.Cf(lpeg.Ct(0) * objectItems, global_options.setObjectKey or rawset)
 	end
 
 

--- a/lua/json/decode/others.lua
+++ b/lua/json/decode/others.lua
@@ -6,6 +6,8 @@ local lpeg = require("lpeg")
 local jsonutil = require("json.util")
 local util = require("json.decode.util")
 
+local rawset = rawset
+
 -- Container module for other JavaScript types (bool, null, undefined)
 module("json.decode.others")
 
@@ -20,7 +22,8 @@ local undefinedCapture = lpeg.P("undefined")
 local defaultOptions = {
 	allowUndefined = true,
 	null = jsonutil.null,
-	undefined = jsonutil.undefined
+	undefined = jsonutil.undefined,
+	setObjectKey = rawset
 }
 
 default = nil -- Let the buildCapture optimization take place

--- a/lua/json/decode/util.lua
+++ b/lua/json/decode/util.lua
@@ -7,6 +7,7 @@ local select = select
 local pairs, ipairs = pairs, ipairs
 local tonumber = tonumber
 local string_char = require("string").char
+local rawset = rawset
 
 local error = error
 local setmetatable = setmetatable
@@ -89,4 +90,9 @@ function get_invalid_character_info(input, index)
 	local _, line_number = parsed:gsub('\n',{})
 	local last_line = parsed:match("\n([^\n]+.)$") or parsed
 	return line_number, #last_line, bad_character, last_line
+end
+
+function setObjectKeyForceNumber(t, key, value)
+	key = tonumber(key) or key
+	return rawset(t, key, value)
 end

--- a/tests/lunit-simple-decode.lua
+++ b/tests/lunit-simple-decode.lua
@@ -46,3 +46,20 @@ function test_decode_object_default_with_null()
 	assert_equal(json.util.null, result.x)
 	assert_not_nil(next(result))
 end
+
+function test_decode_object_with_stringized_numeric_keys_default()
+	local result = assert(json.decode('{"1": "one"}'))
+	assert_equal("one", result["1"])
+	assert_equal(nil, result[1])
+end
+
+function test_decode_object_with_stringized_numeric_keys_force_numeric()
+	local result = assert(
+			json.decode(
+					'{"1": "one"}',
+					{ setObjectKey = assert(json.decode.util.setObjectKeyForceNumber) }
+				)
+		)
+	assert_equal(nil, result["1"])
+	assert_equal("one", result[1])
+end


### PR DESCRIPTION
Hi, Thomas!

Please review my patch regarding configurable object key filter for luajson decode (we discussed this issue on Lua mailing list recently).

I'd like to see this functionality in the nearest release of luajson — as I have to write the code that will depend on it.

Please tell me if I can improve the patch so it will be accepted and released :-)

Thank you,
Alexander.
