### PR TITLE
when json content is empty, it is better to encode lua empty table {} to json empty array [] rather than json object {}.

### DIFF
--- a/lua/json/util.lua
+++ b/lua/json/util.lua
@@ -8,6 +8,7 @@ local tostring = tostring
 local pairs = pairs
 local getmetatable, setmetatable = getmetatable, setmetatable
 local select = select
+local next = next
 
 module("json.util")
 local function foreach(tab, func)


### PR DESCRIPTION
when json content is empty, it is better to encode lua empty table {} to json empty array [] rather than json object {}.
