### PR TITLE
Add option to ignore mismatched array lengths due to `null`/`undefined`.

### DIFF
--- a/lua/json/decode/composite.lua
+++ b/lua/json/decode/composite.lua
@@ -23,6 +23,7 @@ local _ENV = nil
 local defaultOptions = {
 	array = {
 		allowEmptyElement = false,
+		ignoreLength = false,
 		trailingComma = true
 	},
 	object = {

--- a/lua/json/decode/state.lua
+++ b/lua/json/decode/state.lua
@@ -101,7 +101,7 @@ function state_ops.end_array(self)
 		-- Not an empty array
 		self:put_value(true)
 	end
-	if self.active_state ~= #self.active then
+	if self.active_state ~= #self.active and not self.options.array.ignoreLength then
 		-- Store the length in
 		self.active.n = self.active_state
 	end


### PR DESCRIPTION
This change adds an option `array.ignoreLength` which, when set to `true`, prevents adding `n` to tables decoded from arrays with `null` or `undefined` entries, such as `"[null,42]"`.

This allows iterating over the tables using `pairs` without encountering a key/value pair that was not part of the JSON data.

The option defaults to `false` to preserve the current behavior for any existing callers.