### PR TITLE
fix: fix lpeg version detection

### DIFF
--- a/lua/json/decode/util.lua
+++ b/lua/json/decode/util.lua
@@ -97,7 +97,11 @@ local unicode_ignored = (unicode_space + comment)^0
 -- Parse the lpeg version skipping patch-values
 -- LPEG <= 0.7 have no version value... so 0.7 is value
 -- LPEG >= 1.1 uses a string for the version instead of function
-local DecimalLpegVersion = lpeg.version and tonumber((type(lpeg.version) == "string" and lpeg.version or lpeg.version()):match("^(%d+%.%d+)")) or 0.7
+local DecimalLpegVersion = lpeg.version
+		and tonumber(
+			(type(lpeg.version) == "string" and lpeg.version or lpeg.version()):match("(%d+%.%d+)")
+		)
+	or 0.7
 
 local function setObjectKeyForceNumber(t, key, value)
 	key = tonumber(key) or key


### PR DESCRIPTION
This changeset fixes the lpeg version detection to properly handle version > 1.1.

The original fix did not properly parse the string.

Refs: #47