### PR TITLE
Fix global loadstring lookup under strict mode #50

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,6 +92,8 @@ jobs:
           python-version: '3.10'
 
       - name: Run Tests
+        env:
+          TEST_STRICT: 1
         run: |
           ./run_tests.sh "${{ matrix.lua }}" "${{ matrix.lpeg }}"
 

--- a/lua/json/encode/output.lua
+++ b/lua/json/encode/output.lua
@@ -5,7 +5,7 @@
 local type = type
 local assert, error = assert, error
 local table_concat = require("table").concat
-local loadstring = loadstring or load
+local loadstring = rawget(_G or {}, "loadstring") or load
 
 local io = require("io")
 

--- a/lua/json/encode/output_utility.lua
+++ b/lua/json/encode/output_utility.lua
@@ -3,7 +3,7 @@
 	Author: Thomas Harning Jr <harningt@gmail.com>
 ]]
 local setmetatable = setmetatable
-local assert, loadstring = assert, loadstring or load
+local assert, loadstring = assert, rawget(_G or {}, "loadstring") or load
 
 local _ENV = nil
 

--- a/tests/hook_require.lua
+++ b/tests/hook_require.lua
@@ -1,7 +1,58 @@
 local os = require("os")
+
+if os.getenv("TEST_STRICT") then
+	local mt = getmetatable(_G)
+	if not mt then
+		mt = {}
+		setmetatable(_G, mt)
+	end
+	mt.__declared = mt.__declared or {}
+	for k in pairs(_G) do
+		mt.__declared[k] = true
+	end
+	mt.__declared["_ENV"] = true
+
+	local debug_getinfo = debug.getinfo
+	local function what()
+		local d = debug_getinfo(3, "S")
+		return d and d.what or "C"
+	end
+
+	local old_newindex = mt.__newindex
+	mt.__newindex = function(t, n, v)
+		if not mt.__declared[n] then
+			local w = what()
+			if w ~= "main" and w ~= "C" then
+				error("assign to undeclared variable '"..n.."'", 2)
+			end
+			mt.__declared[n] = true
+		end
+		if old_newindex then
+			old_newindex(t, n, v)
+		else
+			rawset(t, n, v)
+		end
+	end
+
+	local old_index = mt.__index
+	mt.__index = function(t, n)
+		if not mt.__declared[n] then
+			local d = debug_getinfo(2, "S")
+			if d and d.source and d.source:match("lua/json/") then
+				error("variable '"..n.."' is not declared", 2)
+			end
+		end
+		if old_index then
+			return old_index(t, n)
+		else
+			return rawget(t, n)
+		end
+	end
+end
+
 local old_require = require
 if os.getenv('LUA_OLD_INIT') then
-	local loadstring = loadstring or load
+	local loadstring = rawget(_G or {}, "loadstring") or load
 	assert(loadstring(os.getenv('LUA_OLD_INIT')))()
 else
 	require("luarocks.require")


### PR DESCRIPTION
### Description
This pull request resolves Issue #50 where importing/using the `json` module under strict mode (e.g. from `strict.lua`) fails. 

The failure happens under Lua 5.2+ because `loadstring or load` performs a global lookup for the `loadstring` variable. Since `loadstring` is not declared or defined in these versions, accessing it directly triggers the global table's `__index` metamethod, causing a strict mode violation error:
```
variable 'loadstring' is not declared
```

### Proposed Changes
- **Safe `loadstring` Check**: Replaced `loadstring or load` with `rawget(_G or {}, "loadstring") or load` in:
  - `lua/json/encode/output.lua`
  - `lua/json/encode/output_utility.lua`
  - `tests/hook_require.lua`
- **Strict Mode Test Coverage**: Implemented a filtered strict mode check in `tests/hook_require.lua` when the `TEST_STRICT` environment variable is active. The check is configured to only throw for undeclared global accesses originating from the library files (`lua/json/*`), bypassing third-party loader environments (like `luarocks` loader which references `unpack`).
- **CI Integration**: Configured the GitHub Actions testing matrix (`.github/workflows/test.yml`) to run the entire test suite (across all Lua versions and interpreters) with `TEST_STRICT=1` enabled.

Closes #50
