### PR TITLE
feat: integrate pl.strict testing and add to CI matrix per #35

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,9 @@ jobs:
           - lua: "lua 5.3"
             lpeg: "1.0.1-1"
           - lua: "lua 5.3"
+            lpeg: "1.0.1-1"
+            strict_module: "pl.strict"
+          - lua: "lua 5.3"
             lpeg: "0.12.2-1"
 
           # Lua 5.4 combinations
@@ -93,7 +96,7 @@ jobs:
 
       - name: Run Tests
         env:
-          TEST_STRICT: 1
+          TEST_STRICT: ${{ matrix.strict_module || '1' }}
         run: |
           ./run_tests.sh "${{ matrix.lua }}" "${{ matrix.lpeg }}"
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -78,6 +78,14 @@ else
     source "$ENV_DIR/bin/activate"
 fi
 
+# Ensure penlight is installed if testing under pl.strict
+if [ "${TEST_STRICT:-}" = "pl.strict" ]; then
+    if ! luarocks list | grep -q penlight; then
+        echo "Installing penlight for pl.strict testing..."
+        luarocks install https://luarocks.org/penlight-1.15.0-1.src.rock
+    fi
+fi
+
 # 3. Run the tests
 echo "Running tests in the target environment..."
 # Clean up any residual coverage file from previous runs

--- a/tests/hook_require.lua
+++ b/tests/hook_require.lua
@@ -1,54 +1,6 @@
 local os = require("os")
 
-if os.getenv("TEST_STRICT") then
-	local mt = getmetatable(_G)
-	if not mt then
-		mt = {}
-		setmetatable(_G, mt)
-	end
-	mt.__declared = mt.__declared or {}
-	for k in pairs(_G) do
-		mt.__declared[k] = true
-	end
-	mt.__declared["_ENV"] = true
-
-	local debug_getinfo = debug.getinfo
-	local function what()
-		local d = debug_getinfo(3, "S")
-		return d and d.what or "C"
-	end
-
-	local old_newindex = mt.__newindex
-	mt.__newindex = function(t, n, v)
-		if not mt.__declared[n] then
-			local w = what()
-			if w ~= "main" and w ~= "C" then
-				error("assign to undeclared variable '"..n.."'", 2)
-			end
-			mt.__declared[n] = true
-		end
-		if old_newindex then
-			old_newindex(t, n, v)
-		else
-			rawset(t, n, v)
-		end
-	end
-
-	local old_index = mt.__index
-	mt.__index = function(t, n)
-		if not mt.__declared[n] then
-			local d = debug_getinfo(2, "S")
-			if d and d.source and d.source:match("lua/json/") then
-				error("variable '"..n.."' is not declared", 2)
-			end
-		end
-		if old_index then
-			return old_index(t, n)
-		else
-			return rawget(t, n)
-		end
-	end
-end
+local test_strict = os.getenv("TEST_STRICT")
 
 local old_require = require
 if os.getenv('LUA_OLD_INIT') then
@@ -58,6 +10,96 @@ else
 	require("luarocks.require")
 end
 local luarocks_require = require
+
+if test_strict and test_strict ~= "" and test_strict ~= "0" and test_strict ~= "false" then
+	if test_strict == "pl.strict" then
+		require("pl.strict")
+		local mt = getmetatable(_G)
+		if mt then
+			local allowed = {
+				newproxy = true,
+				statsfile = true,
+				reportfile = true,
+				configfile = true,
+				runreport = true,
+				deletestats = true,
+				include = true,
+				exclude = true,
+				reporter = true,
+				tick = true,
+				modules = true,
+				unpack = true,
+				_M = true,
+				_NAME = true,
+				_PACKAGE = true,
+				setup = true,
+				teardown = true,
+				setfenv = true,
+				getfenv = true,
+				module = true,
+			}
+			mt.__declared = mt.__declared or {}
+			for k, v in pairs(allowed) do
+				mt.__declared[k] = v
+			end
+			local old_index = mt.__index
+			mt.__index = function(t, n)
+				if n == nil then
+					return nil
+				end
+				return old_index(t, n)
+			end
+		end
+	else
+		local mt = getmetatable(_G)
+		if not mt then
+			mt = {}
+			setmetatable(_G, mt)
+		end
+		mt.__declared = mt.__declared or {}
+		for k in pairs(_G) do
+			mt.__declared[k] = true
+		end
+		mt.__declared["_ENV"] = true
+
+		local debug_getinfo = debug.getinfo
+		local function what()
+			local d = debug_getinfo(3, "S")
+			return d and d.what or "C"
+		end
+
+		local old_newindex = mt.__newindex
+		mt.__newindex = function(t, n, v)
+			if not mt.__declared[n] then
+				local w = what()
+				if w ~= "main" and w ~= "C" then
+					error("assign to undeclared variable '"..n.."'", 2)
+				end
+				mt.__declared[n] = true
+			end
+			if old_newindex then
+				old_newindex(t, n, v)
+			else
+				rawset(t, n, v)
+			end
+		end
+
+		local old_index = mt.__index
+		mt.__index = function(t, n)
+			if not mt.__declared[n] then
+				local d = debug_getinfo(2, "S")
+				if d and d.source and d.source:match("lua/json/") then
+					error("variable '"..n.."' is not declared", 2)
+				end
+			end
+			if old_index then
+				return old_index(t, n)
+			else
+				return rawget(t, n)
+			end
+		end
+	end
+end
 
 function require(module, ...)
 	if module == "json" or module:match("^json%.") then


### PR DESCRIPTION
## Description
This Pull Request integrates support for testing `luajson` under Penlight's strict variable check module (`pl.strict`) and adds it to the CI test matrix.

To make `pl.strict` compatible with the test suite (avoiding global lookup errors on optional globals in `luacov`, `luarocks`, and `lunit`), this change:
1. **Defers Strict Activation**: Postpones enabling strict mode until after core frameworks (`luarocks`, `luacov`, etc.) have loaded.
2. **Pre-declares Environment Globals**: If `TEST_STRICT=pl.strict` is used, the hook pre-declares expected nil-check globals accessed by `luacov`, `luarocks`, and `lunit`.
3. **Guards Nil Index**: Overrides `_G`'s `__index` to handle and skip `nil` key lookups, preventing formatting crashes within `pl.strict`.
4. **CI Matrix Integration**: Configured the `lua 5.3` matrix item to run with `strict_module: "pl.strict"`.
5. **On-demand Penlight Setup**: Updated `run_tests.sh` to install `penlight` via luarocks only when `TEST_STRICT=pl.strict` is specified.

---

## Verification
- Ran regression and unit tests under `TEST_STRICT=pl.strict` locally on Lua 5.3:
  ```bash
  TEST_STRICT=pl.strict ./run_tests.sh "lua 5.3" "1.0.1-1"
  ```
- Ran full local matrix to verify no regressions:
  ```bash
  TEST_STRICT=1 make test-matrix
  ```
